### PR TITLE
clarified the naming convention

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,5 +22,5 @@ panel_custom:
     module_url: /local/automations-tree.js
 ```
 
-3. If your Automations are not structured like _Folder // Folder // AutomationName_, adjust the `divider` variable in `automations-tree.js`.
+3. If your Automations are not named following the pattern _something // something // AutomationName_, adjust the `divider` variable in `automations-tree.js` to use something else than `//`.
 4. Restart Home Assistant


### PR DESCRIPTION
I think that the current documentation is misleading because of the use of "Folder". It took me some time to realize that I could not put my automations in actual filesystem folders and see them in the tree view (wherever they are, they are put at the top of the tree.

After having a look at the code, I see that the naming of the automation (or alias) is the only thing taken into account. 

I think that by not using the name "Folder" and highlighting that this is a naming convention to follow it will get easier for someone just starting to understand how the tree works.